### PR TITLE
Release permissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
     "name": "harmonylang",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "harmonylang",
-            "version": "0.2.3",
+            "version": "0.2.4",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "^0.5.2",
                 "axios": "^0.21.1",
                 "chai": "^4.2.0",
+                "chmodr": "^1.2.0",
                 "command-exists": "^1.2.9",
                 "create-html-element": "^3.0.0",
                 "dotenv": "^8.2.0",
@@ -27,6 +28,7 @@
             "devDependencies": {
                 "@types/adm-zip": "^0.4.33",
                 "@types/chai": "^4.2.14",
+                "@types/chmodr": "^1.0.0",
                 "@types/command-exists": "^1.2.0",
                 "@types/create-html-element": "^2.1.0",
                 "@types/glob": "^7.1.3",
@@ -57,6 +59,15 @@
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.14.tgz",
             "integrity": "sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==",
             "dev": true
+        },
+        "node_modules/@types/chmodr": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/chmodr/-/chmodr-1.0.0.tgz",
+            "integrity": "sha512-S+X+Gy8V1uijitezjzXuan5vHbjllKgnC6q4VrD30HF2WRF6oIwQ/Wfjzvn5tGIIsl4VtRnBQbzqyzBo02juhw==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/command-exists": {
             "version": "1.2.0",
@@ -384,6 +395,11 @@
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/chmodr": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.2.0.tgz",
+            "integrity": "sha512-Y5uI7Iq/Az6HgJEL6pdw7THVd7jbVOTPwsmcPOBjQL8e3N+pz872kzK5QxYGEy21iRys+iHWV0UZQXDFJo1hyA=="
         },
         "node_modules/chokidar": {
             "version": "3.4.3",
@@ -1643,6 +1659,15 @@
             "integrity": "sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==",
             "dev": true
         },
+        "@types/chmodr": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/chmodr/-/chmodr-1.0.0.tgz",
+            "integrity": "sha512-S+X+Gy8V1uijitezjzXuan5vHbjllKgnC6q4VrD30HF2WRF6oIwQ/Wfjzvn5tGIIsl4VtRnBQbzqyzBo02juhw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/command-exists": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@types/command-exists/-/command-exists-1.2.0.tgz",
@@ -1918,6 +1943,11 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
             "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+        },
+        "chmodr": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.2.0.tgz",
+            "integrity": "sha512-Y5uI7Iq/Az6HgJEL6pdw7THVd7jbVOTPwsmcPOBjQL8e3N+pz872kzK5QxYGEy21iRys+iHWV0UZQXDFJo1hyA=="
         },
         "chokidar": {
             "version": "3.4.3",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "devDependencies": {
         "@types/adm-zip": "^0.4.33",
         "@types/chai": "^4.2.14",
+        "@types/chmodr": "^1.0.0",
         "@types/command-exists": "^1.2.0",
         "@types/create-html-element": "^2.1.0",
         "@types/glob": "^7.1.3",
@@ -125,6 +126,7 @@
         "adm-zip": "^0.5.2",
         "axios": "^0.21.1",
         "chai": "^4.2.0",
+        "chmodr": "^1.2.0",
         "command-exists": "^1.2.9",
         "create-html-element": "^3.0.0",
         "dotenv": "^8.2.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,16 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { ProcessManagerImpl } from './processManager';
-import { CHARMONY_COMPILER_DIR, CHARMONY_JSON_OUTPUT, CHARMONY_SCRIPT_PATH, GENERATED_FILES } from "./config";
+import {
+    CHARMONY_COMPILER_DIR,
+    CHARMONY_JSON_OUTPUT,
+    CHARMONY_SCRIPT_PATH,
+    GENERATED_FILES,
+    EXTENSION_DIR
+} from "./config";
 import * as rimraf from "rimraf";
 import * as fs from "fs";
+import * as chmodDr from 'chmodr';
 import { IntermediateJson } from "./charmony/IntermediateJson";
 import CharmonyPanelController_v2 from "./outputPanel/PanelController_v2";
 import * as commandExists from "command-exists";
@@ -16,6 +23,7 @@ const pythonPath = harmonyLangConfig.get('pythonPath');
 const ccPath = harmonyLangConfig.get('ccPath');
 
 export const activate = (context: vscode.ExtensionContext) => {
+    chmodDr.sync(EXTENSION_DIR, 755);
     const runHarmonyCommand = vscode.commands.registerCommand('harmonylang.run', () => {
         const filename = vscode.window.activeTextEditor?.document?.fileName;
         const ext = path.extname(filename || '');
@@ -117,7 +125,7 @@ function runHarmonyServer(context: vscode.ExtensionContext, fullFileName: string
     }
     const rootDirectory = workspace[0].uri.fsPath;
     CharmonyPanelController_v2.currentPanel?.startLoading();
-    runServerAnalysis(rootDirectory, fullFileName, onReceivingIntermediateJSON, 
+    runServerAnalysis(rootDirectory, fullFileName, onReceivingIntermediateJSON,
         msg => {
             console.log(msg);
             CharmonyPanelController_v2.currentPanel?.updateMessage(msg);
@@ -161,7 +169,7 @@ export function runHarmony(context: vscode.ExtensionContext, fullFileName: strin
                     GENERATED_FILES.forEach(f => rimraf.sync(f));
                 } catch (error) {
                     hlConsole.appendLine(error);
-                    hlConsole.show();    
+                    hlConsole.show();
                     CharmonyPanelController_v2.currentPanel?.updateMessage(`Could not create analysis file.`);
                 }
             });


### PR DESCRIPTION
Change file permissions of the extension directory when the extension is activated, set the mode of contents in the extension to `755`. `chmodr` is being used because the native `fs.chmod` does not recursively change file permissions in a directory.