### PR TITLE
Release hot fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -408,7 +408,6 @@
             "dependencies": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
-                "fsevents": "~2.1.2",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "HarmonyLang",
     "description": "VS Code language support for Harmony, a Python-like concurrent programming language.",
     "icon": "images/harmonylang.png",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "publisher": "kevinsun-dev-cornell",
     "repository": "https://github.com/kevinsun-dev/harmonylang",
     "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,6 @@ import {
 } from "./config";
 import * as rimraf from "rimraf";
 import * as fs from "fs";
-import * as chmodDr from 'chmodr';
 import { IntermediateJson } from "./charmony/IntermediateJson";
 import CharmonyPanelController_v2 from "./outputPanel/PanelController_v2";
 import * as commandExists from "command-exists";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,6 @@ const pythonPath = harmonyLangConfig.get('pythonPath');
 const ccPath = harmonyLangConfig.get('ccPath');
 
 export const activate = (context: vscode.ExtensionContext) => {
-    chmodDr.sync(EXTENSION_DIR, 755);
     const runHarmonyCommand = vscode.commands.registerCommand('harmonylang.run', () => {
         const filename = vscode.window.activeTextEditor?.document?.fileName;
         const ext = path.extname(filename || '');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,7 +127,8 @@ function runHarmonyServer(context: vscode.ExtensionContext, fullFileName: string
     CharmonyPanelController_v2.currentPanel?.startLoading();
     runServerAnalysis(rootDirectory, fullFileName, onReceivingIntermediateJSON,
         msg => {
-            console.log(msg);
+            hlConsole.appendLine(msg);
+            hlConsole.show();
             CharmonyPanelController_v2.currentPanel?.updateMessage(msg);
         }
     );

--- a/src/outputPanel/PanelController_v2.ts
+++ b/src/outputPanel/PanelController_v2.ts
@@ -111,10 +111,10 @@ export default class CharmonyPanelController_v2 {
                 JSON.stringify(harmonyJsonData, undefined, 4));
         }
 
-        if (vscode.workspace.workspaceFolders) {
-            console.log("Creating a standalone HTML file");
-            createStandaloneHtml(vscode.workspace.workspaceFolders[0].uri.path, harmonyJsonData);
-        }
+        // if (vscode.workspace.workspaceFolders) {
+            // console.log("Creating a standalone HTML file");
+            // createStandaloneHtml(vscode.workspace.workspaceFolders[0].uri.path, harmonyJsonData);
+        // }
         webview.postMessage({ command: 'load', jsonData: harmonyJsonData });
         webview.onDidReceiveMessage( message => {
             switch (message.command) {

--- a/src/outputPanel/PanelController_v2.ts
+++ b/src/outputPanel/PanelController_v2.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import {Webview} from 'vscode';
 import * as fs from 'fs';
-import {createStandaloneHtml} from "../feature/standaloneHtml";
 import {CHARMONY_HTML_FILE, DEBUG_DIR, RESOURCE_DIR} from "../config";
 import {IntermediateJson} from "../charmony/IntermediateJson";
 import parseCharmony from "../charmony/CharmonyData";


### PR DESCRIPTION
Fixed the source of why visualizer failed on Windows: the standalone html generator.

For some reason (still investigating specific reason), the standalone html generator fails on Windows but not on Unix or MacOS. This fix removes this feature this generator temporarily (which should be fine since the visualizer generally serves the same purpose). Since this was the source of the issue, the `chmod` call is also being removed.