### PR TITLE
Support for nested windows paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "harmonylang",
-    "version": "0.2.4",
+    "version": "0.2.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "harmonylang",
-            "version": "0.2.4",
+            "version": "0.2.6",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,10 @@
                 "key": "alt+shift+n"
             },
             {
+                "command": "harmonylang-server.run",
+                "key": "alt+shift+s"
+            },
+            {
                 "command": "harmonylang.end",
                 "key": "alt+shift+q"
             }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "HarmonyLang",
     "description": "VS Code language support for Harmony, a Python-like concurrent programming language.",
     "icon": "images/harmonylang.png",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "publisher": "kevinsun-dev-cornell",
     "repository": "https://github.com/kevinsun-dev/harmonylang",
     "engines": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ export const CHARMONY_JSON_OUTPUT = path.join(CHARMONY_COMPILER_DIR, "charm.json
 export const PACKAGE_JSON = path.join(EXTENSION_DIR, "package.json");
 export const VERSION_VALUE = JSON.parse(fs.readFileSync(PACKAGE_JSON, "utf-8"))['version'];
 
-export const HARMONY_SERVER_API = "http://localhost:8080/";
+export const HARMONY_SERVER_API = "https://harmonylang.herokuapp.com/";
 
 export const GENERATED_FILES = [
     path.join(CHARMONY_COMPILER_DIR, "charm.dSYM"),

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,10 @@ export const CHARMONY_COMPILER_DIR = path.join(EXTENSION_DIR, "harmony-master");
 export const CHARMONY_SCRIPT_PATH = path.join(CHARMONY_COMPILER_DIR, "harmony");
 export const CHARMONY_JSON_OUTPUT = path.join(CHARMONY_COMPILER_DIR, "charm.json");
 
-export const HARMONY_SERVER_API = "https://harmonylang.herokuapp.com/";
+export const PACKAGE_JSON = path.join(EXTENSION_DIR, "package.json");
+export const VERSION_VALUE = JSON.parse(PACKAGE_JSON)['version'];
+
+export const HARMONY_SERVER_API = "http://localhost:8080/";
 
 export const GENERATED_FILES = [
     path.join(CHARMONY_COMPILER_DIR, "charm.dSYM"),

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import * as fs from "fs";
 
 export const EXTENSION_DIR = path.join(__dirname, "..");
 export const DEBUG_DIR = path.join(EXTENSION_DIR, "debug");
@@ -11,7 +12,7 @@ export const CHARMONY_SCRIPT_PATH = path.join(CHARMONY_COMPILER_DIR, "harmony");
 export const CHARMONY_JSON_OUTPUT = path.join(CHARMONY_COMPILER_DIR, "charm.json");
 
 export const PACKAGE_JSON = path.join(EXTENSION_DIR, "package.json");
-export const VERSION_VALUE = JSON.parse(PACKAGE_JSON)['version'];
+export const VERSION_VALUE = JSON.parse(fs.readFileSync(PACKAGE_JSON, "utf-8"))['version'];
 
 export const HARMONY_SERVER_API = "http://localhost:8080/";
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,8 @@ export const CHARMONY_JSON_OUTPUT = path.join(CHARMONY_COMPILER_DIR, "charm.json
 export const PACKAGE_JSON = path.join(EXTENSION_DIR, "package.json");
 export const VERSION_VALUE = JSON.parse(fs.readFileSync(PACKAGE_JSON, "utf-8"))['version'];
 
-export const HARMONY_SERVER_API = "https://harmonylang.herokuapp.com/";
+type api_endpoint = "https://harmonylang.herokuapp.com/" | `http://localhost:${number}/`;
+export const HARMONY_SERVER_API: api_endpoint = "https://harmonylang.herokuapp.com/";
 
 export const GENERATED_FILES = [
     path.join(CHARMONY_COMPILER_DIR, "charm.dSYM"),

--- a/src/feature/runServerAnalysis.ts
+++ b/src/feature/runServerAnalysis.ts
@@ -5,7 +5,7 @@ import * as FormData from 'form-data';
 import * as AdmZip from 'adm-zip';
 import * as tmp from 'tmp';
 import { IntermediateJson } from '../charmony/IntermediateJson';
-import { HARMONY_SERVER_API } from '../config';
+import { HARMONY_SERVER_API, VERSION_VALUE } from '../config';
 
 export function runServerAnalysis(
     projectDirectory: string,
@@ -21,8 +21,10 @@ export function runServerAnalysis(
     const tempFile = tmp.fileSync().name;
     zip.writeZip(tempFile, async (err) => {
         if (err != null) return;
+        const pathToMainFile = path.relative(projectDirectory, mainFilename);
         bodyFormData.append("file", fs.createReadStream(tempFile));
-        bodyFormData.append("main", path.relative(projectDirectory, mainFilename));
+        bodyFormData.append("main", JSON.stringify(pathToMainFile.split(path.sep)));
+        bodyFormData.append("version", VERSION_VALUE);
         try {
             const response = await axios.post(HARMONY_SERVER_API + "check",
                 bodyFormData,

--- a/src/feature/runServerAnalysis.ts
+++ b/src/feature/runServerAnalysis.ts
@@ -25,6 +25,7 @@ export function runServerAnalysis(
         bodyFormData.append("file", fs.createReadStream(tempFile));
         bodyFormData.append("main", JSON.stringify(pathToMainFile.split(path.sep)));
         bodyFormData.append("version", VERSION_VALUE);
+        bodyFormData.append("source", "vscode");
         try {
             const response = await axios.post(HARMONY_SERVER_API + "check",
                 bodyFormData,


### PR DESCRIPTION
Adds support for DOS-style paths for files nested in a subdirectory. It splits the path to the file from the project root directory using the system path separator as the delimiter. This is then sent to the server as a JSON-serialized array.

Additionally, the current version of the extension and the fact that the service request is from `vscode` is sent to the backend as data as well.

The server now accepts a `version` string and a `source` string in the form data request. The server is already updated and deployed.