### PR TITLE
minor import statement fix

### DIFF
--- a/syntaxes/harmony.tmLanguage.json
+++ b/syntaxes/harmony.tmLanguage.json
@@ -72,7 +72,7 @@
 			"comment": "Import statements used to correctly mark `import`",
 			"patterns": [{
 				"begin": "\\b(?<!\\.)(import)\\b",
-				"end": "\\;$",
+				"end": "\\;|$",
 				"beginCaptures": {
 					"1": {
 						"name": "keyword.control.import.harmony"

--- a/syntaxes/harmony.tmLanguage.json
+++ b/syntaxes/harmony.tmLanguage.json
@@ -333,7 +333,7 @@
 			"match": "(?x)\n and= | or= | mod= | <<= | >>= | //= | \\*\\*=\n | \\+= | -= | /= | @=\n | \\*= | %= | ~= | \\^= | &= | \\|= | =(?!=)\n"
 		},
 		"operator": {
-			"match": "(?x)\n    \\b(?<!\\.)\n   (?:\n   (and | or | not | in | is)   (?# 1)\n        |\n        (for | if | else | await | (?:yield(?:\\s+from)?))  (?# 2)\n  )\n    (?!\\s*:)\\b\n\n    | (<< | >> | & | \\| | \\^ | ~)   (?# 3)\n\n    | (\\*\\* | \\* | \\+ | - | % | // | / | @)  (?# 4)\n\n    | (!= | == | >= | <= | < | >)  (?# 5)\n ( ! | - | ~ | all | any | atLabel | bagsize | choose | min | max | nametag | not | keys | hash | len | processes ) (?# 6)",
+			"match": "(?x)\n    \\b(?<!\\.)\n   (?:\n   (and | or | not | in | is)   (?# 1)\n        |\n        (for | if | else | await | (?:yield(?:\\s+from)?))  (?# 2)\n  )\n    (?!\\s*:)\\b\n\n    | (<< | >> | & | \\| | \\^ | ~)   (?# 3)\n\n    | (\\*\\* | \\* | \\+ | - | % | // | / | @)  (?# 4)\n\n    | (!= | == | >= | <= | < | >)  (?# 5)\n    | ( ! | - | ~ | all | any | atLabel | bagsize | choose | min | max | nametag | not | keys | hash | len | processes ) (?# 6)",
 			"captures": {
 				"1": {
 					"name": "keyword.operator.logical.harmony"


### PR DESCRIPTION
There was an issue where linting for some stuff after an import statement without a semicolon at the end gets messed up (e.g. atomic was not highlighted, function definitions and parameters were assigned to other scopes and had different colors). This should be a fix.