### PR TITLE
Axios - Bug fix

### DIFF
--- a/src/feature/runServerAnalysis.ts
+++ b/src/feature/runServerAnalysis.ts
@@ -30,9 +30,8 @@ export function runServerAnalysis(
             const response = await axios.post(HARMONY_SERVER_API + "/check",
                 bodyFormData,
                 {
-                    headers: {
-                    ...bodyFormData.getHeaders(),
-                }
+                    headers: {...bodyFormData.getHeaders()},
+                    validateStatus() { return true; }
             });
             if (200 <= response.status && response.status < 300) {
                 const data = response.data;


### PR DESCRIPTION
Enables all return code to be valid when using `axios.post`. Without it, any response that responded with anything outside the 200-300 range using `axios` threw a runtime error...