### PR TITLE
update installation strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,24 +42,6 @@
                     "scope": "machine-overridable",
                     "default": null,
                     "description": "Python 3 installation path"
-                },
-                "harmonylang.commandPath": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "scope": "machine-overridable",
-                    "default": null,
-                    "description": "Path of the Harmony command"
-                },
-                "harmonylang.libraryPath": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "scope": "machine-overridable",
-                    "default": null,
-                    "description": "Path of where Harmony is installed"
                 }
             }
         },

--- a/src/SystemCommands.ts
+++ b/src/SystemCommands.ts
@@ -32,9 +32,21 @@ export default class SystemCommands {
             return null;
         }
     }
-    
+
+    public static async updateHarmonyPythonCommandPath(path: string) {
+        const config = SystemCommands.getHarmonyLangConfiguration();
+        // Prefer Python configurations for HarmonyLang.
+        await config.update('pythonPath', path, true);
+    }
 
     public static async getPythonCommandPath(): Promise<string | null> {
+        const config = SystemCommands.getHarmonyLangConfiguration();
+        // Prefer Python configurations for HarmonyLang.
+        const harmonyPythonPath = config.get('pythonPath');
+        if (typeof harmonyPythonPath === 'string' && fs.existsSync(harmonyPythonPath)) {
+            return harmonyPythonPath;
+        }
+
         const actualPythonPath = vscode.workspace.getConfiguration('python').get('pythonPath');
         if (typeof actualPythonPath === 'string' && fs.existsSync(actualPythonPath)) {
             return actualPythonPath;
@@ -44,13 +56,6 @@ export default class SystemCommands {
         if (typeof anotherPossiblePythonPath === 'string' && fs.existsSync(anotherPossiblePythonPath)) {
             return anotherPossiblePythonPath;
         }
-    
-        const config = SystemCommands.getHarmonyLangConfiguration();
-        const harmonyPythonPath = config.get('pythonPath');
-        if (typeof harmonyPythonPath === 'string' && fs.existsSync(harmonyPythonPath)) {
-            return harmonyPythonPath;
-        }
-    
         return which('python3')
             .catch(() => which('python'))
             .catch(() => null);

--- a/src/SystemCommands.ts
+++ b/src/SystemCommands.ts
@@ -1,42 +1,28 @@
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import * as which from 'which';
-import * as path from 'path';
-import ProcessManager from './vscode/ProcessManager';
 
 export default class SystemCommands {
     public static getHarmonyLangConfiguration() {
         return vscode.workspace.getConfiguration('harmonylang');
     }
 
-    public static async getHarmonyCommandPath(): Promise<string | null> {
-        const config = SystemCommands.getHarmonyLangConfiguration();
-        const commandPath = config.get('commandPath');
-        if (typeof commandPath === 'string' && fs.existsSync(commandPath)) {
-            return commandPath;
-        }
-        try {
-            const cmdPath = await which('harmony');
-            config.update('commandPath', cmdPath, true);
-            return cmdPath;
-        } catch {
-            const installPath = await SystemCommands.getPythonInstallScriptPath();
-            if (!installPath) {
-                return null;
-            }
-            const possibleHarmonyPath = path.join(installPath, 'harmony');
-            if (fs.existsSync(possibleHarmonyPath)) {
-                config.update('commandPath', possibleHarmonyPath, true);
-                return possibleHarmonyPath;
-            }
-            return null;
-        }
-    }
-
     public static async updateHarmonyPythonCommandPath(path: string) {
         const config = SystemCommands.getHarmonyLangConfiguration();
         // Prefer Python configurations for HarmonyLang.
         await config.update('pythonPath', path, true);
+    }
+
+    public static async getAllPossiblePythonCommandPaths(): Promise<string[]> {
+        const pythonPaths: unknown[] = [];
+        pythonPaths.push(
+            SystemCommands.getHarmonyLangConfiguration().get('pythonPath'),
+            ...await which('python3', { all: true }),
+            ...await which('python', { all: true }),
+            vscode.workspace.getConfiguration('python').get('pythonPath'),
+            vscode.workspace.getConfiguration('python').get('defaultInterpreterPath'),
+        );
+        return pythonPaths.filter((x): x is string => typeof x === 'string' && fs.existsSync(x));
     }
 
     public static async getPythonCommandPath(): Promise<string | null> {
@@ -46,37 +32,7 @@ export default class SystemCommands {
         if (typeof harmonyPythonPath === 'string' && fs.existsSync(harmonyPythonPath)) {
             return harmonyPythonPath;
         }
-
-        const actualPythonPath = vscode.workspace.getConfiguration('python').get('pythonPath');
-        if (typeof actualPythonPath === 'string' && fs.existsSync(actualPythonPath)) {
-            return actualPythonPath;
-        }
-
-        const anotherPossiblePythonPath = vscode.workspace.getConfiguration('python').get('defaultInterpreterPath');
-        if (typeof anotherPossiblePythonPath === 'string' && fs.existsSync(anotherPossiblePythonPath)) {
-            return anotherPossiblePythonPath;
-        }
-        return which('python3')
-            .catch(() => which('python'))
-            .catch(() => null);
+        return null;
     }
 
-    public static async getPythonInstallScriptPath(): Promise<string | null> {
-        const pythonCommand = await SystemCommands.getPythonCommandPath();
-        if (!pythonCommand) return null;
-    
-        const command = [pythonCommand, '-c', 'import os,sysconfig;print(sysconfig.get_path("scripts",f"{os.name}_user"))'];
-        return new Promise((resolve) => {
-            ProcessManager.startCommand(command, {}, (err, stdout) => {
-                if (err) {
-                    return resolve(null);
-                }
-                const possibleInstallPath = stdout.trim();
-                if (!fs.existsSync(possibleInstallPath)) {
-                    return resolve(null);
-                }
-                return resolve(possibleInstallPath);
-            });
-        });
-    }
 }

--- a/src/SystemCommands.ts
+++ b/src/SystemCommands.ts
@@ -3,28 +3,43 @@ import * as vscode from 'vscode';
 import * as which from 'which';
 
 export default class SystemCommands {
-    public static getHarmonyLangConfiguration() {
+    private static getHarmonyLangConfiguration() {
         return vscode.workspace.getConfiguration('harmonylang');
     }
 
+    /**
+     * Set the extension-configuration of pythonPath.
+     */
     public static async updateHarmonyPythonCommandPath(path: string) {
         const config = SystemCommands.getHarmonyLangConfiguration();
         // Prefer Python configurations for HarmonyLang.
         await config.update('pythonPath', path, true);
     }
 
+    /**
+     * Returns all possible file paths that 'may' be Python3.
+     * If an extension-configuration of pythonPath exists, then it is the first element
+     * of the returned array.
+     */
     public static async getAllPossiblePythonCommandPaths(): Promise<string[]> {
         const pythonPaths: unknown[] = [];
+        // Prefer the extension-set pythonPath first, and then remaining possible paths
+        // as fallback.
         pythonPaths.push(
             SystemCommands.getHarmonyLangConfiguration().get('pythonPath'),
-            ...await which('python3', { all: true }),
-            ...await which('python', { all: true }),
             vscode.workspace.getConfiguration('python').get('pythonPath'),
             vscode.workspace.getConfiguration('python').get('defaultInterpreterPath'),
+            ...await which('python3', { all: true }),
+            ...await which('python', { all: true }),
         );
+        // TODO: Convert this array into an iterator that lazily checks if the element is
+        // a string & exists (& checks if it is >= python3.6).
         return pythonPaths.filter((x): x is string => typeof x === 'string' && fs.existsSync(x));
     }
 
+    /**
+     * Retrieves the extension-set pythonPath, if it exists.
+     */
     public static async getPythonCommandPath(): Promise<string | null> {
         const config = SystemCommands.getHarmonyLangConfiguration();
         // Prefer Python configurations for HarmonyLang.

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,12 +10,6 @@ export const MELODY_LAUNCHER = path.join(RESOURCE_DIR, 'charmony-v3.html');
 export const EXAMPLE_CHARM_JSON = path.join(RESOURCE_DIR, 'charm-example.json');
 
 const HOME_DIRECTORY = path.resolve(os.homedir());
-export const INSTALL_HARMONY_COMMAND = [
-    'pip',
-    'install',
-    '--upgrade',
-    'harmony-model-checker'
-];
 export const HARMONY_DIRECTORY = path.join(HOME_DIRECTORY, '.harmony-model-checker');
 
 export const CHARMONY_COMPILER_DIR = path.join(HARMONY_DIRECTORY, 'harmony-compiler');

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,8 @@ export const CHARMONY_SCRIPT_PATH = path.join(CHARMONY_COMPILER_DIR, 'harmony');
 export const PACKAGE_JSON = path.join(EXTENSION_DIR, 'package.json');
 export const VERSION_VALUE = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf-8'))['version'];
 
+export const HARMONY_ENTRY_SCRIPT = 'import re\nimport sys\nfrom harmony_model_checker.main import main\nif __name__ == \'__main__\':\n\tsys.argv[0] = re.sub(r\'(-script\\.pwd|\\.exe)?$\', \'\', sys.argv[0])\n\tsys.exit(main())';
+
 export const GENERATED_FILES = [
     path.join(CHARMONY_COMPILER_DIR, 'charm.dSYM'),
     path.join(CHARMONY_COMPILER_DIR, 'harmony.html'),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import {
     TransportKind
 } from 'vscode-languageclient/node';
 import runHarmony from './vscode-commands/execHarmony';
-import runInstall from './vscode-commands/install';
+import runInstall, { printReadableInstallMessage } from './vscode-commands/install';
 import endHarmonyProcesses from './vscode-commands/endProcesses';
 
 
@@ -33,10 +33,12 @@ export const activate = (context: vscode.ExtensionContext) => {
         'harmonylang.install',
         () => {
             runInstall()
-                .then(msg => OutputConsole.println(msg))
+                .then(msg => {
+                    printReadableInstallMessage(msg);
+                    OutputConsole.println(msg);
+                })
                 .catch((errMessage: string) => {
-                    Message.error('Failed to install Harmony using pip');
-                    Message.error(errMessage);
+                    printReadableInstallMessage(errMessage);
                     OutputConsole.println(errMessage);
                     OutputConsole.show();
                 });
@@ -113,8 +115,7 @@ export const activate = (context: vscode.ExtensionContext) => {
     runInstall()
         .then(msg => OutputConsole.println(msg))
         .catch((errMessage: string) => {
-            Message.error('Failed to install Harmony using pip');
-            Message.error(errMessage);
+            printReadableInstallMessage(errMessage);
             OutputConsole.println(errMessage);
             OutputConsole.show();
         });

--- a/src/vscode-commands/execHarmony.ts
+++ b/src/vscode-commands/execHarmony.ts
@@ -12,6 +12,7 @@ import OutputConsole from '../vscode/OutputConsole';
 import ProcessManager from '../vscode/ProcessManager';
 import { IntermediateJson } from '../charmony';
 import SystemCommands from '../SystemCommands';
+import { HARMONY_ENTRY_SCRIPT } from '../config';
 
 
 const parser = new ArgumentParser();
@@ -73,11 +74,12 @@ export default async function runHarmony(
     flags?: string
 ): Promise<void> {
     OutputConsole.clear();
-    const harmonyScript = await SystemCommands.getHarmonyCommandPath();
-    if (!harmonyScript || !fs.existsSync(harmonyScript)) {
+    const getPythonCommandPath = await SystemCommands.getPythonCommandPath();
+
+    if (!getPythonCommandPath) {
         Message.error(
-            'Cannot find the Harmony script.',
-            'Check if you have installed Harmony.',
+            'Cannot find the Python script.',
+            'Check if you have installed Python.',
         );
         return;
     }
@@ -107,7 +109,9 @@ export default async function runHarmony(
     const gvFilename = tmpFilename + '.gv';
 
     const charmonyCompileCommand = [
-        harmonyScript,
+        getPythonCommandPath,
+        '-c',
+        HARMONY_ENTRY_SCRIPT,
         ...flagArgs,
         '-o', hvmFilename,
         '-o', hcoFilename,

--- a/src/vscode-commands/execHarmony.ts
+++ b/src/vscode-commands/execHarmony.ts
@@ -77,8 +77,7 @@ export default async function runHarmony(
     if (!harmonyScript || !fs.existsSync(harmonyScript)) {
         Message.error(
             'Cannot find the Harmony script.',
-            'Check if you have installed Harmony via [Install Harmony] or',
-            'added the path to Harmony via [Add Harmony Library Path].'
+            'Check if you have installed Harmony.',
         );
         return;
     }

--- a/src/vscode-commands/install.ts
+++ b/src/vscode-commands/install.ts
@@ -21,8 +21,10 @@ export default async function runInstall() {
     if (pythonPaths.length === 0) {
         throw 'Could not find a python path. Please install Python3 or report this if you believe it is an error.';
     }
+
     OutputConsole.println('Attempting to install harmony-model-checker via the following:');
     pythonPaths.forEach(p => OutputConsole.println(`\t${p}`));
+
     const errorMessages: string[] = [];
     for (const p of pythonPaths) {
         const {error, stdout, stderr} = await ProcessManager.startCommandAsync([p, '-m', 'pip', ...INSTALL_HARMONY_COMMAND_ARGS], {});

--- a/src/vscode-commands/install.ts
+++ b/src/vscode-commands/install.ts
@@ -50,19 +50,27 @@ export default async function runInstall() {
  * user readable output.
  */
 export async function printReadableInstallMessage(msgs:string) {
-    const msgLines = msgs.trim().split('\n');
+    const MAX_MESSAGES = 3;
+    // Reversing the message order, as higher priority errors are ordered closer to the bottom.
+    const msgLines = msgs.trim().split('\n').reverse();
     let highestOutputLevel = 0;
     let harmonyInstalled = false;
+    let totalMessages = 0;
 
     for (const mIndex in msgLines){    
-        const msg = msgLines[mIndex];    
+        const msg = msgLines[mIndex].trim();  
         if (msg.startsWith('ERROR:')){
             highestOutputLevel = 2;
+            totalMessages++;
             Message.error(msg);
         } else if (msg.startsWith('WARNING:')) {
             highestOutputLevel = 1;
+            totalMessages++;
             Message.warn(msg);
         }
+
+        // If too many notifications are sent, none are displayed.
+        if (totalMessages >= MAX_MESSAGES) break;
 
         if (msg.includes('Requirement already satisfied: harmony-model-checker')){
             harmonyInstalled = true;
@@ -72,8 +80,8 @@ export async function printReadableInstallMessage(msgs:string) {
     if (harmonyInstalled){
         // If Harmony is already installed, that's all they need to know.
         Message.info('Harmony already installed.');
-    } else {
+    } else if (highestOutputLevel == 0) {
         // If Harmony isn't installed, this is either a successful install or a non-pip error.
-        Message.info(msgLines[msgLines.length - 1]);
+        Message.info(msgLines[0]);
     }
 }

--- a/src/vscode-commands/install.ts
+++ b/src/vscode-commands/install.ts
@@ -1,21 +1,55 @@
-import { INSTALL_HARMONY_COMMAND } from '../config';
+import SystemCommands from '../SystemCommands';
+import Message from '../vscode/Message';
 import OutputConsole from '../vscode/OutputConsole';
 import ProcessManager from '../vscode/ProcessManager';
+
+
+const INSTALL_HARMONY_COMMAND_ARGS = [
+    'install',
+    '--upgrade',
+    '--user',
+    'harmony-model-checker'
+];
 
 /**
  * This will run the Harmony installation script.
  * If Harmony was already instead in the extension's directory,
- * then delete the existing installation and re-install.
+ * then update with the latest version from PyPi
  */
 export default async function runInstall() {
+    const pythonPath = await SystemCommands.getPythonCommandPath();
     return new Promise<string>((resolve, reject) => {
-        ProcessManager.startCommand(INSTALL_HARMONY_COMMAND, {}, (err, stdout, stderr) => {
+        if (!pythonPath) {
+            reject('Could not find a python path. Please install Python3 or report this if you believe it is an error.');
+            return;
+        }
+        ProcessManager.startCommand([pythonPath, '-m', 'pip', ...INSTALL_HARMONY_COMMAND_ARGS], {}, (err, stdout, stderr) => {
             OutputConsole.clear();
             if (err) {
-                reject(stdout + '\n\n' + stderr);
+                reject(stdout + '\n\n' + stderr + '\n\n');
                 return;
             }
+            // Set the pythonPath to the HarmonyLang one if it works.
+            SystemCommands.updateHarmonyPythonCommandPath(pythonPath);
             resolve(stdout);
         });
     });
+}
+
+/**
+ * Parses the output messages from pip to produce
+ * user readable output.
+ */
+export async function printReadableInstallMessage(msgs:string) {
+    const msgLines = msgs.trim().split('\n');
+    const lastLine = msgLines[msgLines.length - 1];
+    if (lastLine.startsWith('Requirement already satisfied: ')){
+        Message.info('Harmony already installed.');
+    } else {
+        if (lastLine.startsWith('ERROR:')){
+            Message.error(lastLine);
+        } else {
+            Message.info(lastLine);
+        }
+    }
 }

--- a/src/vscode-commands/install.ts
+++ b/src/vscode-commands/install.ts
@@ -51,14 +51,28 @@ export default async function runInstall() {
  */
 export async function printReadableInstallMessage(msgs:string) {
     const msgLines = msgs.trim().split('\n');
-    const lastLine = msgLines[msgLines.length - 1];
-    if (lastLine.startsWith('Requirement already satisfied: ')){
+    let highestOutputLevel = 0;
+    let harmonyInstalled = false;
+
+    for (const msg in msgLines){        
+        if (msg.startsWith('ERROR:')){
+            highestOutputLevel = 2;
+            Message.error(msg);
+        } else if (msg.startsWith('WARNING:')) {
+            highestOutputLevel = 1;
+            Message.warn(msg);
+        }
+
+        if (msg.includes('Requirement already satisfied: harmony-model-checker')){
+            harmonyInstalled = true;
+        }
+    }
+
+    if (harmonyInstalled){
+        // If Harmony is already installed, that's all they need to know.
         Message.info('Harmony already installed.');
     } else {
-        if (lastLine.startsWith('ERROR:')){
-            Message.error(lastLine);
-        } else {
-            Message.info(lastLine);
-        }
+        // If Harmony isn't installed, this is either a successful install or a non-pip error.
+        Message.info(msgLines[msgLines.length - 1]);
     }
 }

--- a/src/vscode-commands/install.ts
+++ b/src/vscode-commands/install.ts
@@ -57,20 +57,19 @@ export async function printReadableInstallMessage(msgs:string) {
     let harmonyInstalled = false;
     let totalMessages = 0;
 
-    for (const mIndex in msgLines){    
-        const msg = msgLines[mIndex].trim();  
-        if (msg.startsWith('ERROR:')){
-            highestOutputLevel = 2;
-            totalMessages++;
-            Message.error(msg);
-        } else if (msg.startsWith('WARNING:')) {
-            highestOutputLevel = 1;
-            totalMessages++;
-            Message.warn(msg);
+    for (const msg of msgLines){
+        // We cap the number of messages at 3 to avoid overloading the notification tray
+        if (totalMessages < MAX_MESSAGES){
+            if (msg.startsWith('ERROR:')){
+                highestOutputLevel = 2;
+                totalMessages++;
+                Message.error(msg);
+            } else if (msg.startsWith('WARNING:')) {
+                highestOutputLevel = 1;
+                totalMessages++;
+                Message.warn(msg);
+            }
         }
-
-        // If too many notifications are sent, none are displayed.
-        if (totalMessages >= MAX_MESSAGES) break;
 
         if (msg.includes('Requirement already satisfied: harmony-model-checker')){
             harmonyInstalled = true;

--- a/src/vscode-commands/install.ts
+++ b/src/vscode-commands/install.ts
@@ -54,7 +54,8 @@ export async function printReadableInstallMessage(msgs:string) {
     let highestOutputLevel = 0;
     let harmonyInstalled = false;
 
-    for (const msg in msgLines){        
+    for (const mIndex in msgLines){    
+        const msg = msgLines[mIndex];    
         if (msg.startsWith('ERROR:')){
             highestOutputLevel = 2;
             Message.error(msg);

--- a/src/vscode/ProcessManager.ts
+++ b/src/vscode/ProcessManager.ts
@@ -7,6 +7,17 @@ export default class ProcessManager {
     private static commandCount = 0;
     private static processesAreKilled = false
 
+    public static startCommandAsync(
+        cmd: string[],
+        options: child_process.ExecOptions,
+    ): Thenable<{error: child_process.ExecException | null; stdout: string; stderr: string}> {
+        return new Promise(resolve => {
+            this.startCommand(cmd, options, (error, stdout, stderr) => {
+                resolve({error, stdout, stderr});
+            });
+        });
+    }
+
     public static startCommand(
         cmd: string[],
         options: child_process.ExecOptions,

--- a/syntaxes/harmony.tmLanguage.json
+++ b/syntaxes/harmony.tmLanguage.json
@@ -95,7 +95,7 @@
 				},
 				{
 					"name": "keyword.control.flow.harmony",
-					"match": "(?x)\n  \\b(?<!\\.)( where | invariant | atomically | del | var | assert | possibly | let | when | for | elif | else | if | pass | while )\\b\n"
+					"match": "(?x)\n  \\b(?<!\\.)( where | invariant | atomically | del | var | assert | sequential | possibly | let | when | for | elif | else | if | pass | while )\\b\n"
 				}
 			]
 		},
@@ -983,7 +983,7 @@
 			]
 		},
 		"illegal-names": {
-			"match": "(?x)\n  \\b(?:\n    (\n      and | assert | async | await | let | break | continue | def\n      | del | elif | else | except | finally | for | from | global\n      | if | in | is | nonlocal | not | or | pass | raise | return | try | while | with\n      | yield\n    )  )\\b\n",
+			"match": "(?x)\n  \\b(?:\n    (\n      and | assert | sequential | async | await | let | break | continue | def\n      | del | elif | else | except | finally | for | from | global\n      | if | in | is | nonlocal | not | or | pass | raise | return | try | while | with\n      | yield\n    )  )\\b\n",
 			"captures": {
 				"1": {
 					"name": "keyword.control.flow.harmony"


### PR DESCRIPTION
This avoids the assumption of what `pip` is named as and more.

Change summary:
- Remove dependency of `harmonylang.commandPath` and `harmonylang.libraryPath` (this one isn't even being used)
- Install `harmony-model-checker` by calling pip as a Python module:
  - `/path/to/python3 -m pip install --upgrade --user harmony_model_checker`
- Invoke `harmony` by calling from the Python interpreter instead of calling the `harmony` script file:
  - `/path/to/python3 -c 'import re\nimport sys\nfrom harmony_model_checker.main import main\nif __name__ == \'__main__\':\n\tsys.argv[0] = re.sub(r\'(-script\\.pwd|\\.exe)?$\', \'\', sys.argv[0])\n\tsys.exit(main())' ...args`