### PR TITLE
Make HarmonyLang work with updated Melody Visualizer's Output Pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "HarmonyLang",
     "description": "VS Code language support for Harmony, a Python-like concurrent programming language.",
     "icon": "images/harmonylang.png",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "publisher": "kevinsun-dev-cornell",
     "repository": "https://github.com/kevinsun-dev/harmonylang",
     "engines": {

--- a/src/vscode-commands/execHarmony.ts
+++ b/src/vscode-commands/execHarmony.ts
@@ -146,10 +146,10 @@ export default async function runHarmony(
         CharmonyPanelController_v2.currentPanel?.startLoading();
         OutputConsole.clear();
         OutputConsole.println(stdout);
+        CharmonyPanelController_v2.currentPanel?.updateMessage(stdout);
         if (error) {
             OutputConsole.println(error.message);
             Message.error(error.message);
-            CharmonyPanelController_v2.currentPanel?.updateMessage(stdout);
             return;
         }
         const results: CharmonyTopLevelLatest = JSON.parse(fs.readFileSync(hcoFilename, 'utf-8'));


### PR DESCRIPTION
A slight change ensures HarmonyLang can display console output in the new Melody Visualizer's output pane:
<img width="1440" alt="Screenshot 2024-01-21 at 1 01 30 PM" src="https://github.com/harmonylang/harmonylang/assets/12884206/9b788f7a-7cd0-4972-9b8f-db2cb7858dd2">
